### PR TITLE
Temporary screenshot fix.

### DIFF
--- a/src/brevis/display.clj
+++ b/src/brevis/display.clj
@@ -29,18 +29,6 @@ Copyright 2012, 2013 Kyle Harrington"
     (:import [java.awt.image BufferedImage]
            [javax.imageio ImageIO]))
 
-(defn screenshot 
-   "Take a screenshot."
-   [filename]
-   (begin-with-graphics-thread)
-   (Basic3D/screenshot filename)
-   (end-with-graphics-thread))  
-
-;(defn screenshot-hack; won't compile any changes/ cannot find sourcepath- Tim 9/8/2014
-;  "Take a screenshot."
-;  [filename]
-;  (write-image (str filename ".png") (screenshot-image)))
-
 
 (defn screenshot-image
    "Take a screenshot and return an image (BufferedImage for now)."
@@ -49,3 +37,10 @@ Copyright 2012, 2013 Kyle Harrington"
    (let [img (Basic3D/screenshotImage)]     
      (end-with-graphics-thread)
      img))
+
+(defn screenshot
+    "Take a screenshot."
+    [filename]
+    (write-image (str filename ".png") (screenshot-image)))
+
+

--- a/src/brevis/example/swarm.clj
+++ b/src/brevis/example/swarm.clj
@@ -50,14 +50,6 @@ Copyright 2012, 2013 Kyle Harrington"
 (def max-acceleration 10)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;## Taking screenshots - temporary fix - Tim S. 9/8/2014
-
-(defn screenshot-hack
-  "Take a screenshot."
-  [filename]
-  (write-image (str filename ".png") (screenshot-image)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ## Birds
 
 (defn bird?


### PR DESCRIPTION
Managed to get a local screenshot function to work in the swarm example, but when trying to add it to display.clj and run swarm example the debug window says to edit source path. When set to src and rerun the swarm example debug window still asks to edit source path. Screenshot shows what happens when the local screenshot function is commented out and swarm example is run with the same screenshot function in display.clj
![1_display_screenshot_uncommented](https://cloud.githubusercontent.com/assets/7042260/4211437/996cd6cc-3888-11e4-81b7-83816cb17dc0.png)
![2_swarm_screenshot_commented](https://cloud.githubusercontent.com/assets/7042260/4211435/9967e13a-3888-11e4-89bf-ca38776622d1.png)
![3_error_source_path_edit](https://cloud.githubusercontent.com/assets/7042260/4211436/9969b32a-3888-11e4-8d0b-899971019368.png)
